### PR TITLE
Remove tailing slashes from routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,5 @@ cython_debug/
 .vscode
 
 # Volumes
+volumes
 volumes/*

--- a/app/domain/file/router.py
+++ b/app/domain/file/router.py
@@ -13,7 +13,7 @@ router = APIRouter()
 
 
 @router.post(
-    "/",
+    "",
     response_model=FilePublic,
     status_code=status.HTTP_201_CREATED,
     summary="Upload a file",
@@ -39,7 +39,7 @@ def upload_file(
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[FilePublic],
     summary="List user files",
     description="Get a list of all files uploaded by the current user.",

--- a/app/domain/task/router.py
+++ b/app/domain/task/router.py
@@ -16,7 +16,7 @@ from app.exceptions.exceptions import ForbiddenException
 router = APIRouter()
 
 
-@router.post("/", response_model=TaskPublic)
+@router.post("", response_model=TaskPublic)
 async def create_task(
     user: OptionallyAuthorizedUserDep,
     form_data: TaskCreate,
@@ -54,7 +54,7 @@ async def get_task(
     return task
 
 
-@router.get("/", response_model=List[TaskPublic])
+@router.get("", response_model=List[TaskPublic])
 async def get_tasks(
     user: AuthorizedUserDep,
     task_service: TaskServiceDep,


### PR DESCRIPTION
Remove tailing slashes from routes because next js does not like tailing slashes and makes redirect instead proxying request